### PR TITLE
Fix SC2015 shellcheck warning in device-size check

### DIFF
--- a/skills/android-emulator/scripts/emu.sh
+++ b/skills/android-emulator/scripts/emu.sh
@@ -132,7 +132,9 @@ load_device_size() {
       | tr -d '\r' > "$SIZE_CACHE"
   fi
   read -r DEV_W DEV_H < "$SIZE_CACHE"
-  [ -n "${DEV_W:-}" ] && [ -n "${DEV_H:-}" ] || die "could not read device size (is the emulator booted?)"
+  if [ -z "${DEV_W:-}" ] || [ -z "${DEV_H:-}" ]; then
+    die "could not read device size (is the emulator booted?)"
+  fi
 }
 
 # Convert a screenshot-space coordinate (360-wide image) to device pixels.


### PR DESCRIPTION
## Summary

- Rewrites the `A && B || C` pattern on the device-size guard as an explicit `if/fi` so shellcheck is satisfied and the intent is unambiguous
- `tools/lint.sh` now exits 0 on a clean tree

Closes #4

## Test plan

- [x] `tools/lint.sh` — clean
- [x] `tools/run-tests.sh skills/android-emulator` — all 66 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)