### PR TITLE
Fix screenshot command on Linux/WSL2: replace sips with ImageMagick

### DIFF
--- a/skills/android-emulator/scripts/emu.sh
+++ b/skills/android-emulator/scripts/emu.sh
@@ -132,7 +132,9 @@ load_device_size() {
       | tr -d '\r' > "$SIZE_CACHE"
   fi
   read -r DEV_W DEV_H < "$SIZE_CACHE"
-  [ -n "${DEV_W:-}" ] && [ -n "${DEV_H:-}" ] || die "could not read device size (is the emulator booted?)"
+  if [ -z "${DEV_W:-}" ] || [ -z "${DEV_H:-}" ]; then
+    die "could not read device size (is the emulator booted?)"
+  fi
 }
 
 # Convert a screenshot-space coordinate (360-wide image) to device pixels.

--- a/skills/android-emulator/scripts/emu.sh
+++ b/skills/android-emulator/scripts/emu.sh
@@ -197,9 +197,16 @@ cmd="${1:-help}"; [ "$#" -gt 0 ] && shift
 case "$cmd" in
   screenshot)
     adb -s "$DEVICE" exec-out screencap -p > "$SHOT_FULL"
-    sips --resampleWidth "$SHOT_WIDTH" \
-         -s format jpeg -s formatOptions "$SHOT_QUALITY" \
-         "$SHOT_FULL" --out "$SHOT" >/dev/null
+    if convert --version 2>/dev/null | grep -qi "imagemagick"; then
+      convert "$SHOT_FULL" -resize "${SHOT_WIDTH}x" \
+              -quality "$SHOT_QUALITY" "$SHOT"
+    elif command -v sips >/dev/null 2>&1; then
+      sips --resampleWidth "$SHOT_WIDTH" \
+           -s format jpeg -s formatOptions "$SHOT_QUALITY" \
+           "$SHOT_FULL" --out "$SHOT" >/dev/null
+    else
+      die "no image conversion tool found; install ImageMagick (apt install imagemagick / brew install imagemagick)"
+    fi
     echo "$SHOT"
     ;;
 

--- a/skills/android-emulator/tests/dispatch.bats
+++ b/skills/android-emulator/tests/dispatch.bats
@@ -132,12 +132,25 @@ teardown() { emu_teardown; }
 
 # --- screenshot --------------------------------------------------------------
 
-@test "screenshot pipes screencap into sips and prints the resized path" {
+@test "screenshot uses convert when ImageMagick is available and prints the resized path" {
+  run_emu screenshot
+  [ "$status" -eq 0 ]
+  assert_called "screencap -p"
+  assert_called "-resize 360x"
+  refute_called "sips"
+  [[ "$output" == *"$TEST_TMP/android-emu-shot-bats.jpg"* ]]
+}
+
+@test "screenshot falls back to sips when convert is not ImageMagick" {
+  local fake_bin="$TEST_TMP/fake_bin"
+  mkdir -p "$fake_bin"
+  printf '#!/usr/bin/env bash\necho "SomeOtherTool 1.0"\n' > "$fake_bin/convert"
+  chmod +x "$fake_bin/convert"
+  export PATH="$fake_bin:$PATH"
   run_emu screenshot
   [ "$status" -eq 0 ]
   assert_called "screencap -p"
   assert_called "sips --resampleWidth 360"
-  # Output is the path to the resized JPEG.
   [[ "$output" == *"$TEST_TMP/android-emu-shot-bats.jpg"* ]]
 }
 

--- a/skills/android-emulator/tests/stubs/convert
+++ b/skills/android-emulator/tests/stubs/convert
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Stubbed `convert` (ImageMagick). Identifies as ImageMagick on --version;
+# logs args and creates the output file (last arg) on normal invocations.
+set -u
+if [ "${1:-}" = "--version" ]; then
+  echo "Version: ImageMagick 6.9.12-98 Q16 x86_64"
+  exit 0
+fi
+echo "convert $*" >> "${STUB_LOG:-/dev/null}"
+output="${*: -1}"
+: > "$output"
+exit 0


### PR DESCRIPTION
## Summary

- `sips` is macOS-only; the `screenshot` command was broken on Linux/WSL2
- `screenshot` now tries `convert` first (verified as ImageMagick via `--version`), falls back to `sips` for stock macOS installs, and `die`s with a clear install hint if neither is found
- Adds a `convert` stub and two new bats tests covering the ImageMagick primary path and the `sips` fallback

Closes #1

## Test plan

- [x] `tools/lint.sh` — clean
- [x] `tools/run-tests.sh skills/android-emulator` — all 67 tests pass (2 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)