### PR TITLE
Fix SKILL.md semantics example: retain ensureSemantics() handle

### DIFF
--- a/skills/android-emulator/SKILL.md
+++ b/skills/android-emulator/SKILL.md
@@ -128,9 +128,15 @@ Heuristic: after a tap, check `ui-list` first. Screenshot only if it doesn't ans
    import 'package:flutter/foundation.dart';
    import 'package:flutter/semantics.dart';
 
+   // Must be top-level (or otherwise long-lived). If the handle returned by
+   // ensureSemantics() is not retained, it is immediately garbage-collected
+   // and semantics stay disabled.
+   SemanticsHandle? _semanticsHandle;
+
    void main() {
+     WidgetsFlutterBinding.ensureInitialized();
      if (kDebugMode) {
-       SemanticsBinding.instance.ensureSemantics();
+       _semanticsHandle = SemanticsBinding.instance.ensureSemantics();
      }
      runApp(const MyApp());
    }


### PR DESCRIPTION
## Summary

- The existing `ensureSemantics()` code snippet in SKILL.md discarded the returned `SemanticsHandle` — it is immediately garbage-collected if not retained, leaving semantics silently disabled (the root cause of `ui-list` returning only `android:id/content`)
- Fixes the snippet to store the handle in a top-level variable and adds `WidgetsFlutterBinding.ensureInitialized()`, which is required before accessing `SemanticsBinding`
- Adds an inline comment explaining why the handle must be retained

Closes #3

## Test plan

- [x] `tools/lint.sh` — clean
- [x] `tools/run-tests.sh skills/android-emulator` — all 67 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)